### PR TITLE
Cv2 not require for save card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ doc
 vendor
 composer.phar
 *.log
+.idea
 
 php-cs-fixer.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/src/Judopay/Model/SaveCard.php
+++ b/src/Judopay/Model/SaveCard.php
@@ -25,7 +25,6 @@ class SaveCard extends Model
         = array(
             'yourConsumerReference',
             'cardNumber',
-            'cv2',
             'expiryDate',
         );
 }

--- a/tests/SaveCardTest.php
+++ b/tests/SaveCardTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests;
+
+use Tests\Base\PaymentTests;
+use Tests\Builders\SaveCardBuilder;
+
+abstract class SaveCardTests extends PHPUnit_Framework_TestCase
+{
+    public function testValidSaveCard()
+    {
+        $saveCard = $this->getBuilder()
+            ->setAttribute('cv2', '')
+            ->build(ConfigHelper::getConfig());
+
+        $result = $saveCard->create();
+
+        AssertionHelper::assertSuccessfulPayment($result);
+    }
+
+    public function testValidSaveCardWithNoCv2()
+    {
+        $saveCard = $this->getBuilder()
+            ->build(ConfigHelper::getConfig());
+
+        $result = $saveCard->create();
+
+        AssertionHelper::assertSuccessfulPayment($result);
+    }
+
+    protected function getBuilder()
+    {
+        return new SaveCardBuilder();
+    }
+}

--- a/tests/SaveCardTest.php
+++ b/tests/SaveCardTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests;
 
-use Tests\Base\PaymentTests;
+use PHPUnit_Framework_TestCase;
 use Tests\Builders\SaveCardBuilder;
+use Tests\Helpers\AssertionHelper;
+use Tests\Helpers\ConfigHelper;
 
 abstract class SaveCardTests extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
We do not require CV2 on the server for save card calls. This removes the validation for the field