### PR TITLE
Update Void to VoidTransaction to prevent collisions with reserved php names

### DIFF
--- a/spec/Judopay/Model/VoidSpec.php
+++ b/spec/Judopay/Model/VoidSpec.php
@@ -8,7 +8,7 @@ class VoidSpec extends ModelObjectBehavior
 {
     public function it_is_initializable()
     {
-        $this->shouldHaveType('Judopay\Model\Void');
+        $this->shouldHaveType('Judopay\Model\VoidTransaction');
     }
 
     public function it_should_create_a_new_refund()
@@ -18,7 +18,7 @@ class VoidSpec extends ModelObjectBehavior
         );
 
         $modelBuilder = new VoidBuilder();
-        /** @var \Judopay\Model\Void|VoidSpec $this */
+        /** @var \Judopay\Model\VoidTransaction|VoidSpec $this */
         $this->setAttributeValues(
             $modelBuilder->compile()->getAttributeValues()
         );

--- a/src/Judopay/Model/VoidTransaction.php
+++ b/src/Judopay/Model/VoidTransaction.php
@@ -5,7 +5,7 @@ namespace Judopay\Model;
 use Judopay\DataType;
 use Judopay\Model;
 
-class Void extends Model
+class VoidTransaction extends Model
 {
     protected $resourcePath = 'transactions/voids';
     protected $validApiMethods = array('create');


### PR DESCRIPTION
We are seeing

Cannot use 'Void' as class name as it is reserved

When trying to issue void calls in PHP 7.1, updating this name to something unreserved would resolve this