### PR TITLE
Fixes faulty required attribute equality check

### DIFF
--- a/src/Judopay/Model.php
+++ b/src/Judopay/Model.php
@@ -194,7 +194,7 @@ class Model
         foreach ($this->requiredAttributes as $requiredAttribute) {
             if (!in_array($requiredAttribute, $existingAttributes)
                 || $data[$requiredAttribute] === ''
-                || $data[$requiredAttribute] = null
+                || $data[$requiredAttribute] === null
             ) {
                 $errors[] = $requiredAttribute.' is missing or empty';
             }


### PR DESCRIPTION
`$data[$requiredAttribute] = null` returns `null` which is falsy