### PR TITLE
ResumeComplete3dOptionalCv2-JR-5219

### DIFF
--- a/src/Judopay/Model/CompleteThreeDSecureTwo.php
+++ b/src/Judopay/Model/CompleteThreeDSecureTwo.php
@@ -17,7 +17,6 @@ class CompleteThreeDSecureTwo extends Model
 
     protected $requiredAttributes
         = array(
-            'receiptId',
-            'cv2'
+            'receiptId'
         );
 }

--- a/src/Judopay/Model/ResumeThreeDSecureTwo.php
+++ b/src/Judopay/Model/ResumeThreeDSecureTwo.php
@@ -19,7 +19,6 @@ class ResumeThreeDSecureTwo extends Model
     protected $requiredAttributes
         = array(
             'receiptId',
-            'cv2',
             'methodCompletion'
         );
 }

--- a/tests/Base/ThreeDSecureTwoTests.php
+++ b/tests/Base/ThreeDSecureTwoTests.php
@@ -149,6 +149,52 @@ abstract class ThreeDSecureTwoTests extends PaymentTests
         AssertionHelper::assertRequiresThreeDSecureTwoChallengeCompletion($resumeResult);
     }
 
+    public function testPaymentWithThreedSecureTwoResumeTransactionNoCv2()
+    {
+        // Build a threeDSecureTwo payment
+        $threeDSecureTwo = array(
+            'authenticationSource'      => "Browser",
+            'methodNotificationUrl'     => "https://www.test.com",
+            'challengeNotificationUrl'  => "https://www.test.com"
+        );
+
+        $cardPayment = $this->getPaymentBuilder()
+            ->setType(CardPaymentBuilder::THREEDSTWO_VISA_CARD)
+            ->setThreeDSecureTwoFields($threeDSecureTwo)
+            ->build(ConfigHelper::getSafeChargeConfig());
+
+        $paymentResult = [];
+
+        try {
+            $paymentResult = $cardPayment->create();
+        } catch (BadResponseException $e) {
+            $this->fail('The request was expected to be successful.'); // We do not expect any exception
+        }
+
+        // We should have received a request for additional device data gathering
+        AssertionHelper::assertRequiresThreeDSecureTwoDeviceDetails($paymentResult);
+
+        // Build the Resume3d request for the payment after its device gathering happened
+        // But without setting a CV2 as it is an optional value for that step
+        $resumeThreeDSecureTwo = $this->getResumeThreeDSecureTwoBuilder($paymentResult['receiptId'])
+            ->setThreeDSecureTwoMethodCompletion("Yes")
+            ->build(ConfigHelper::getSafeChargeConfig());
+
+        Assert::assertNotNull($resumeThreeDSecureTwo);
+
+        try {
+            $resumeResult = $resumeThreeDSecureTwo->update();
+            $this->fail('The request was expected to raise an exception.'); // We do not expect any exception
+        } catch (BadResponseException $e) {
+            // We do not expect any model exception because CV2 is not a mandatory request parameter
+            $this->fail('The request was expected to raise an ApiException.');
+        }
+        catch (ApiException $e) {
+            // But we expect an API exception as this API key doesn't have optional CV2
+            assert::assertEquals("Sorry, the security code entered is invalid. Please check your details and try again.", $e->getFieldErrors()[0]->getMessage());
+        }
+    }
+
     /*
      * This cannot run as a full automated test because of a step involving a web browser
      */

--- a/tests/Base/ThreeDSecureTwoTests.php
+++ b/tests/Base/ThreeDSecureTwoTests.php
@@ -190,7 +190,8 @@ abstract class ThreeDSecureTwoTests extends PaymentTests
             $this->fail('The request was expected to raise an ApiException.');
         } catch (ApiException $e) {
             // But we expect an API exception as this API key doesn't have optional CV2
-            assert::assertEquals("Sorry, the security code entered is invalid. Please check your details and try again.", $e->getFieldErrors()[0]->getMessage());
+            $expectedException = "Sorry, the security code entered is invalid. Please check your details and try again.";
+            assert::assertEquals($expectedException, $e->getFieldErrors()[0]->getMessage());
         }
     }
 

--- a/tests/Base/ThreeDSecureTwoTests.php
+++ b/tests/Base/ThreeDSecureTwoTests.php
@@ -190,8 +190,8 @@ abstract class ThreeDSecureTwoTests extends PaymentTests
             $this->fail('The request was expected to raise an ApiException.');
         } catch (ApiException $e) {
             // But we expect an API exception as this API key doesn't have optional CV2
-            $expectedException = "Sorry, the security code entered is invalid. Please check your details and try again.";
-            assert::assertEquals($expectedException, $e->getFieldErrors()[0]->getMessage());
+            $expected = "Sorry, the security code entered is invalid. Please check your details and try again.";
+            assert::assertEquals($expected, $e->getFieldErrors()[0]->getMessage());
         }
     }
 

--- a/tests/Base/ThreeDSecureTwoTests.php
+++ b/tests/Base/ThreeDSecureTwoTests.php
@@ -188,8 +188,7 @@ abstract class ThreeDSecureTwoTests extends PaymentTests
         } catch (BadResponseException $e) {
             // We do not expect any model exception because CV2 is not a mandatory request parameter
             $this->fail('The request was expected to raise an ApiException.');
-        }
-        catch (ApiException $e) {
+        } catch (ApiException $e) {
             // But we expect an API exception as this API key doesn't have optional CV2
             assert::assertEquals("Sorry, the security code entered is invalid. Please check your details and try again.", $e->getFieldErrors()[0]->getMessage());
         }

--- a/tests/ThreeDSecureTest.php
+++ b/tests/ThreeDSecureTest.php
@@ -44,8 +44,8 @@ class ThreeDSecureTest extends TestCase
         // Update the existing payment with a PUT
         $threeDSecureResult = $threeDSecureCompletion->update();
 
-        // The payment has a successful status
-        AssertionHelper::assertSuccessfulPayment($threeDSecureResult);
+        // The payment has a declined status because the PaRes is not the correct one
+        AssertionHelper::assertDeclinedPayment($threeDSecureResult);
     }
 
     public function testUpdateWrongThreeDSecurePayment()


### PR DESCRIPTION
- Removed cv2 from Required Attributes for CompleteThreeDSecureTwo and ResumeThreeDSecureTwo models
- Updated test cases