### PR TITLE
Support Guzzle 7 (backward compatibility with Guzzle 6)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "repositories": [],
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/guzzle": "~6.0 | ^7.0",
         "pimple/pimple": "~3.0",
         "psr/log": "^1.0",
         "ext-openssl": ">=0.0.0",


### PR DESCRIPTION
This PR adds support for Guzzle 7, maintaining Guzzle 6 as an option for older versions of PHP and existing projects currently using it.

It allows the SDK to be used with new projects where other dependencies are enforcing Guzzle 7.