### PR TITLE
Fix factory exception creation when response body is empty

### DIFF
--- a/src/Judopay/Exception/ApiException.php
+++ b/src/Judopay/Exception/ApiException.php
@@ -40,6 +40,10 @@ class ApiException extends RuntimeException
         // Parse the response in an array
         $parsedBody = json_decode($responseBodyAsString, true);
 
+        if (!is_array($parsedBody)) {
+            $parsedBody = [];
+        }
+
         $category = ArrayHelper::get(
             $parsedBody,
             'category',


### PR DESCRIPTION
During the outage on 6th January the following type exceptions appeared in our logs

```
Uncaught exception: Argument 1 passed to Judopay\Helper\ArrayHelper::get() must be of the type array, null given, called in judopay/judopay-sdk/src/Judopay/Exception/ApiException.php on line 46
```

As a result of the above the expected ApiException was not thrown by the SDK in response to the outage. For future issues we'd like to be able to catch such exceptions so we can be alerted immediately.

This PR introduces a minor fix that prevents the above error from occurring.