### PR TITLE
Allow for psr/log ^1.0 || ^2.0 || ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.5",
         "guzzlehttp/guzzle": "~6.0 | ^7.0",
         "pimple/pimple": "~3.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "ext-openssl": ">=0.0.0",
         "ext-json": "*",
         "ext-curl": "*"


### PR DESCRIPTION
Update `psr/log` in compose to allow for `^1.0 || ^2.0 || ^3.0`.

This package only uses an instance of `NullLogger` -> https://github.com/Judopay/Judo-PHP/blob/e8737ae5e66cdb7cfd4afce08abc0b6f4eddecc8/src/Judopay/Configuration.php#L7

